### PR TITLE
CLEAN-1: Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: '5.9'
+
+      - name: Show Swift version
+        run: swift --version
+
+      - name: Build
+        run: swift build -v
+
+      - name: Run Tests
+        run: swift test -v


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow for build and test
- CI runs on all pull requests and pushes to main
- Uses macOS 14 runner with Swift 5.9

## After Merge
Configure branch protection in GitHub Settings:
1. Go to **Settings** → **Branches** → **Add rule**
2. Branch pattern: `main`
3. Enable **Require status checks to pass** → select `Build and Test`

## Jira
[CLEAN-1](https://srikalyan.atlassian.net/browse/CLEAN-1)