### PR TITLE
CLEAN-3: Add auto-merge workflow with shipit label

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code Owners for CleanDiff
+# These users will be automatically requested for review on PRs
+
+# Default owner for all files
+* @srikalyan

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,37 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  auto-merge:
+    name: Enable Auto Merge
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'shipit'
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check if user is a code owner
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          # Check if user is listed in CODEOWNERS
+          if grep -q "@${ACTOR}" .github/CODEOWNERS; then
+            echo "User '${ACTOR}' is a code owner. Proceeding with auto-merge."
+          else
+            echo "::error::Only code owners can use the shipit label. User '${ACTOR}' is not listed in CODEOWNERS."
+            exit 1
+          fi
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
- Add auto-merge workflow triggered by `shipit` label
- Only code owners (defined in CODEOWNERS) can trigger auto-merge
- Uses GitHub's native auto-merge feature (waits for all checks to pass)

## Files Added
- `.github/workflows/auto-merge.yml` - Auto-merge workflow
- `.github/CODEOWNERS` - Defines @srikalyan as code owner

## Prerequisites (after merge)
1. Enable **"Allow auto-merge"** in repo Settings → General
2. Create the `shipit` label in the repository
3. Enable **"Require review from Code Owners"** in branch protection (optional but recommended)

## Jira
[CLEAN-3](https://srikalyan.atlassian.net/browse/CLEAN-3)